### PR TITLE
fix(metric.state) put child-class in AbstractMetric

### DIFF
--- a/src/Monitoring/Metric/AbstractMetric.php
+++ b/src/Monitoring/Metric/AbstractMetric.php
@@ -16,7 +16,7 @@ abstract class AbstractMetric implements AttributeInterface
     public function getState(): MetricStateEnum
     {
         if ($this->state === null) {
-            throw new \RuntimeException(__CLASS__.'::$state is not set.');
+            throw new \RuntimeException(static::class.'::$state is not set.');
         }
 
         return $this->state;


### PR DESCRIPTION
When $state is not set, we want to know the child class.