### PR TITLE
chore: remove implicitly marking parameter as nullable deprecation

### DIFF
--- a/src/Normalizer/AttributeNormalizer.php
+++ b/src/Normalizer/AttributeNormalizer.php
@@ -20,7 +20,7 @@ class AttributeNormalizer implements NormalizerInterface, NormalizerAwareInterfa
     /**
      * @param AttributeInterface $object
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         $data = [
             'name' => $object->getName(),
@@ -44,7 +44,7 @@ class AttributeNormalizer implements NormalizerInterface, NormalizerAwareInterfa
         return $data;
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof AttributeInterface;
     }

--- a/src/Normalizer/EnumNormalizer.php
+++ b/src/Normalizer/EnumNormalizer.php
@@ -13,12 +13,12 @@ class EnumNormalizer implements NormalizerInterface
     /**
      * @param MetricStateEnum|SensorStateEnum $object
      */
-    public function normalize($object, string $format = null, array $context = []): string
+    public function normalize($object, ?string $format = null, array $context = []): string
     {
         return $object->value;
     }
 
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof MetricStateEnum || $data instanceof SensorStateEnum;
     }


### PR DESCRIPTION
Sali,

with php8.4.2 we have some deprecations:

`app-1     | {"level":"info","ts":1744122242.3692372,"msg":"PHP Deprecated:  ApiPlatform\\Metadata\\Property\\Factory\\InheritedPropertyNameInterfaceCollectionFactory::__construct(): Implicitly marking parameter $decorated as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/api-platform/core/src/Metadata/Property/Factory/InheritedPropertyNameInterfaceCollectionFactory.php on line 31","syslog_level":"info"}
app-1     | {"level":"info","ts":1744122242.455177,"msg":"PHP Deprecated:  Gesdinet\\JWTRefreshTokenBundle\\Security\\Http\\Authenticator\\RefreshTokenAuthenticator::start(): Implicitly marking parameter $authException as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/gesdinet/jwt-refresh-token-bundle/Security/Http/Authenticator/RefreshTokenAuthenticator.php on line 181","syslog_level":"info"}
app-1     | {"level":"info","ts":1744122242.5563369,"msg":"PHP Deprecated:  whatwedo\\MonitorBundle\\Normalizer\\AttributeNormalizer::normalize(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/whatwedo/monitor-bundle/src/Normalizer/AttributeNormalizer.php on line 23","syslog_level":"info"}
app-1     | {"level":"info","ts":1744122242.556362,"msg":"PHP Deprecated:  whatwedo\\MonitorBundle\\Normalizer\\AttributeNormalizer::supportsNormalization(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/whatwedo/monitor-bundle/src/Normalizer/AttributeNormalizer.php on line 47","syslog_level":"info"}
app-1     | {"level":"info","ts":1744122242.5564456,"msg":"PHP Deprecated:  whatwedo\\MonitorBundle\\Normalizer\\EnumNormalizer::normalize(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/whatwedo/monitor-bundle/src/Normalizer/EnumNormalizer.php on line 16","syslog_level":"info"}
app-1     | {"level":"info","ts":1744122242.5564532,"msg":"PHP Deprecated:  whatwedo\\MonitorBundle\\Normalizer\\EnumNormalizer::supportsNormalization(): Implicitly marking parameter $format as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/whatwedo/monitor-bundle/src/Normalizer/EnumNormalizer.php on line 21","syslog_level":"info"}`
