### PR TITLE
chore(api): doctrine update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,13 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ ubuntu-latest ]
-                php: [ '8.1', '8.2' ]
-                symfony: [ '6.4.*', '7.0.*' ]
+                php: [ '8.2', '8.3', '8.4' ]
+                symfony: [ '6.4.*', '7.0.*', '7.1.*', '7.2.*' ]
                 exclude:
                   - php: '8.1'
                     symfony: '7.0.*'
+                  - php: '8.1'
+                    symfony: '7.2.*'
 
         steps:
             - uses: actions/checkout@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 operating-system: [ ubuntu-latest ]
                 php: [ '8.1', '8.2' ]
-                symfony: [ '6.3.*', '6.4.*', '7.0.*' ]
+                symfony: [ '6.4.*', '7.0.*' ]
                 exclude:
                   - php: '8.1'
                     symfony: '7.0.*'

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
-        "symfony/framework-bundle": "^6.3|^7.0",
-        "symfony/serializer": "^6.3|^7.0"
+        "php": ">=8.2",
+        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/serializer": "^6.4|^7.0"
     },
     "require-dev": {
         "nyholm/symfony-bundle-test": "^3.0",
@@ -22,14 +22,14 @@
         "whatwedo/php-coding-standard": "^1.0",
         "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^9.5",
-        "symfony/browser-kit": "^6.3|^7.0",
-        "symfony/css-selector": "^6.3|^7.0",
-        "symfony/phpunit-bridge": "^6.3|^7.0",
-        "doctrine/doctrine-bundle": "^2.7",
+        "symfony/browser-kit": "^6.4|^7.0",
+        "symfony/css-selector": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0",
+        "doctrine/doctrine-bundle": "^2.14",
         "doctrine/doctrine-migrations-bundle": "^3.2",
-        "doctrine/orm": "^2.14",
-        "symfony/twig-bundle": "^6.3|^7.0",
-        "symfony/messenger": "^6.3|^7.0",
+        "doctrine/orm": "^3.0.0",
+        "symfony/twig-bundle": "^6.4|^7.0",
+        "symfony/messenger": "^6.4|^7.0",
         "symfony/mercure-bundle": "^0.3"
     },
     "autoload": {

--- a/src/Monitoring/Sensor/Database/DoctrineDbal.php
+++ b/src/Monitoring/Sensor/Database/DoctrineDbal.php
@@ -37,10 +37,10 @@ class DoctrineDbal extends AbstractSensor implements ServiceSubscriberInterface
          * @var string $name
          * @var Connection $connection
          */
-        foreach ($this->container->get(ManagerRegistry::class)->getConnections() as $name => $connection) {
+        foreach ($this->container->get(ManagerRegistry::class)->getConnections() as $connection) {
             try {
                 $connection->executeQuery(
-                    $connection->getDriver()->getDatabasePlatform()->getDummySelectSQL()
+                    $connection->getDriver()->getDatabasePlatform($connection)->getDummySelectSQL()
                 );
             } catch (Exception $e) {
                 $this->details['exception'] = $e->getMessage();


### PR DESCRIPTION
The current implementation of `src/Monitoring/Sensor/Database/DoctrineDbal.php` is incompatible with `doctrine/dbal` `v4`. This was fixed in this MR. Additionally symfony version 6.3 was dropped, because it's no longer maintained. 